### PR TITLE
fix: Update static instantiation in ArrayList.php

### DIFF
--- a/src/Types/ArrayList.php
+++ b/src/Types/ArrayList.php
@@ -13,7 +13,7 @@ class ArrayList extends AbstractList
 {
     public static function from(iterable $items): static
     {
-        return new self($items);
+        return new static($items);
     }
 
     public function prepend(mixed $item, string|int $key = null): static


### PR DESCRIPTION
Use `static` instead of `self` for consistency and better inheritance handling. This change ensures proper instantiation of the ArrayList class. 🛠️